### PR TITLE
change epd_digital_read to read the argument pin instead of BUSY_PIN

### DIFF
--- a/1.54inch_e-paper/raspberrypi/python/epdif.py
+++ b/1.54inch_e-paper/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/1.54inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/1.54inch_e-paper_b/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/1.54inch_e-paper_c/raspberrypi/python/epdif.py
+++ b/1.54inch_e-paper_c/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/2.13inch_e-paper/raspberrypi/python/epdif.py
+++ b/2.13inch_e-paper/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/2.13inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/2.13inch_e-paper_b/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/2.7inch_e-paper/raspberrypi/python/epdif.py
+++ b/2.7inch_e-paper/raspberrypi/python/epdif.py
@@ -45,7 +45,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/2.7inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/2.7inch_e-paper_b/raspberrypi/python/epdif.py
@@ -45,7 +45,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/2.9inch_e-paper/raspberrypi/python/epdif.py
+++ b/2.9inch_e-paper/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/2.9inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/2.9inch_e-paper_b/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/4.2inch_e-paper/raspberrypi/python/epdif.py
+++ b/4.2inch_e-paper/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/4.2inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/4.2inch_e-paper_b/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/7.5inch_e-paper/raspberrypi/python/epdif.py
+++ b/7.5inch_e-paper/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)

--- a/7.5inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/7.5inch_e-paper_b/raspberrypi/python/epdif.py
@@ -41,7 +41,7 @@ def epd_digital_write(pin, value):
     GPIO.output(pin, value)
 
 def epd_digital_read(pin):
-    return GPIO.input(BUSY_PIN)
+    return GPIO.input(pin)
 
 def epd_delay_ms(delaytime):
     time.sleep(delaytime / 1000.0)


### PR DESCRIPTION
`epd_digital_read` in `epdif.py` (in all of them, as they are essentially identical) does not use its argument (`pin`) - it makes no difference what pin is requested, `BUSY_PIN` is always read. This is not very critical since no other pins are ever read by the code, though.

Changed to use `pin` instead.