### PR TITLE
Fixing issue #11 for all display types.

### DIFF
--- a/1.54inch_e-paper/raspberrypi/python/epd1in54.py
+++ b/1.54inch_e-paper/raspberrypi/python/epd1in54.py
@@ -154,7 +154,7 @@ class EPD:
         '''
         @brief: convert an image to a buffer
         '''
-        buf = [0x00] * (self.width * self.height / 8)
+        buf = [0x00] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -172,7 +172,7 @@ class EPD:
                 # Set the bits for the column of pixels
                 # at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] |= 0x80 >> (x % 8)
+                    buf[int((x + y * self.width) / 8)] |= 0x80 >> (x % 8)
         return buf
 
     def set_frame_memory(self, image, x, y):

--- a/1.54inch_e-paper/raspberrypi/python/epd1in54.py
+++ b/1.54inch_e-paper/raspberrypi/python/epd1in54.py
@@ -221,8 +221,7 @@ class EPD:
         self.set_memory_pointer(0, 0)
         self.send_command(WRITE_RAM)
         # send the color data
-        for i in range(0, self.width / 8 * self.height):
-            self.send_data(color)
+        self.send_data(color)
 
     def display_frame(self):
         '''

--- a/1.54inch_e-paper/raspberrypi/python/epdif.py
+++ b/1.54inch_e-paper/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/1.54inch_e-paper_b/raspberrypi/python/epd1in54b.py
+++ b/1.54inch_e-paper_b/raspberrypi/python/epd1in54b.py
@@ -214,7 +214,7 @@ class EPD:
             self.send_data(self.lut_red1[count])
 
     def get_frame_buffer(self, image):
-        buf = [0xFF] * (self.width * self.height / 8)
+        buf = [0xFF] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -228,14 +228,14 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] == 0:
-                    buf[(x + y * self.width) / 8] &= ~(0x80 >> (x % 8))
+                    buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         return buf
 
     def display_frame(self, frame_buffer_black, frame_buffer_red):
         if (frame_buffer_black != None):
             self.send_command(DATA_START_TRANSMISSION_1)           
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 temp = 0x00
                 for bit in range(0, 4):
                     if (frame_buffer_black[i] & (0x80 >> bit) != 0):
@@ -250,7 +250,7 @@ class EPD:
         if (frame_buffer_red != None):
             self.send_command(DATA_START_TRANSMISSION_2)
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_red[i])  
             self.delay_ms(2)        
 
@@ -316,9 +316,9 @@ class EPD:
         if (x < 0 or x >= EPD_WIDTH or y < 0 or y >= EPD_HEIGHT):
             return
         if (colored):
-            frame_buffer[(x + y * EPD_WIDTH) / 8] &= ~(0x80 >> (x % 8))
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] &= ~(0x80 >> (x % 8))
         else:
-            frame_buffer[(x + y * EPD_WIDTH) / 8] |= 0x80 >> (x % 8)
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] |= 0x80 >> (x % 8)
 
     def display_string_at(self, frame_buffer, x, y, text, font, colored):
         image = Image.new('1', (self.width, self.height))

--- a/1.54inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/1.54inch_e-paper_b/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### FILE END ###

--- a/1.54inch_e-paper_b/raspberrypi/python/main.py
+++ b/1.54inch_e-paper_b/raspberrypi/python/main.py
@@ -42,13 +42,13 @@ def main():
     frame_red = [0xFF] * (epd.width * epd.height / 8)
 
     # For simplicity, the arguments are explicit numerical coordinates
-    epd.draw_rectangle(frame_black, 10, 60, 50, 110, COLORED);
-    epd.draw_line(frame_black, 10, 60, 50, 110, COLORED);
-    epd.draw_line(frame_black, 50, 60, 10, 110, COLORED);
-    epd.draw_circle(frame_black, 120, 80, 30, COLORED);
-    epd.draw_filled_rectangle(frame_red, 10, 130, 50, 180, COLORED);
-    epd.draw_filled_rectangle(frame_red, 0, 6, 200, 26, COLORED);
-    epd.draw_filled_circle(frame_red, 120, 150, 30, COLORED);
+    epd.draw_rectangle(frame_black, 10, 60, 50, 110, COLORED)
+    epd.draw_line(frame_black, 10, 60, 50, 110, COLORED)
+    epd.draw_line(frame_black, 50, 60, 10, 110, COLORED)
+    epd.draw_circle(frame_black, 120, 80, 30, COLORED)
+    epd.draw_filled_rectangle(frame_red, 10, 130, 50, 180, COLORED)
+    epd.draw_filled_rectangle(frame_red, 0, 6, 200, 26, COLORED)
+    epd.draw_filled_circle(frame_red, 120, 150, 30, COLORED)
 
     # write strings to the buffer
     font = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeMonoBold.ttf', 18)

--- a/1.54inch_e-paper_c/raspberrypi/python/epd1in54c.py
+++ b/1.54inch_e-paper_c/raspberrypi/python/epd1in54c.py
@@ -215,7 +215,7 @@ class EPD:
             self.send_data(self.lut_red1[count])
 
     def get_frame_buffer(self, image):
-        buf = [0xFF] * (self.width * self.height / 8)
+        buf = [0xFF] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -229,20 +229,20 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] == 0:
-                    buf[(x + y * self.width) / 8] &= ~(0x80 >> (x % 8))
+                    buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         return buf
 
     def display_frame(self, frame_buffer_black, frame_buffer_red):
         if (frame_buffer_black != None):
             self.send_command(DATA_START_TRANSMISSION_1)           
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_black[i]) 
             self.delay_ms(2)                  
         if (frame_buffer_red != None):
             self.send_command(DATA_START_TRANSMISSION_2)
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_red[i])  
             self.delay_ms(2)        
 
@@ -308,9 +308,9 @@ class EPD:
         if (x < 0 or x >= EPD_WIDTH or y < 0 or y >= EPD_HEIGHT):
             return
         if (colored):
-            frame_buffer[(x + y * EPD_WIDTH) / 8] &= ~(0x80 >> (x % 8))
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] &= ~(0x80 >> (x % 8))
         else:
-            frame_buffer[(x + y * EPD_WIDTH) / 8] |= 0x80 >> (x % 8)
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] |= 0x80 >> (x % 8)
 
     def display_string_at(self, frame_buffer, x, y, text, font, colored):
         image = Image.new('1', (self.width, self.height))

--- a/1.54inch_e-paper_c/raspberrypi/python/epdif.py
+++ b/1.54inch_e-paper_c/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### FILE END ###

--- a/1.54inch_e-paper_c/raspberrypi/python/main.py
+++ b/1.54inch_e-paper_c/raspberrypi/python/main.py
@@ -43,13 +43,13 @@ def main():
     frame_red = [0xFF] * (epd.width * epd.height / 8)
 
     # For simplicity, the arguments are explicit numerical coordinates
-    epd.draw_rectangle(frame_black, 10, 60, 50, 110, COLORED);
-    epd.draw_line(frame_black, 10, 60, 50, 110, COLORED);
-    epd.draw_line(frame_black, 50, 60, 10, 110, COLORED);
-    epd.draw_circle(frame_black, 100, 80, 30, COLORED);
-#    epd.draw_filled_rectangle(frame_red, 10, 130, 50, 180, COLORED);
-    epd.draw_filled_rectangle(frame_red, 0, 6, 152, 26, COLORED);
-#    epd.draw_filled_circle(frame_red, 120, 150, 30, COLORED);
+    epd.draw_rectangle(frame_black, 10, 60, 50, 110, COLORED)
+    epd.draw_line(frame_black, 10, 60, 50, 110, COLORED)
+    epd.draw_line(frame_black, 50, 60, 10, 110, COLORED)
+    epd.draw_circle(frame_black, 100, 80, 30, COLORED)
+#    epd.draw_filled_rectangle(frame_red, 10, 130, 50, 180, COLORED)
+    epd.draw_filled_rectangle(frame_red, 0, 6, 152, 26, COLORED)
+#    epd.draw_filled_circle(frame_red, 120, 150, 30, COLORED)
 
     # write strings to the buffer
     font = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeMonoBold.ttf', 18)

--- a/2.13inch_e-paper/raspberrypi/python/epd2in13.py
+++ b/2.13inch_e-paper/raspberrypi/python/epd2in13.py
@@ -152,7 +152,7 @@ class EPD:
  #  @brief: convert an image to a buffer
  ##
     def get_frame_buffer(self, image):
-        buf = [0x00] * (self.width * self.height / 8)
+        buf = [0x00] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -166,7 +166,7 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] |= 0x80 >> (x % 8)
+                    buf[int((x + y * self.width) / 8)] |= 0x80 >> (x % 8)
         return buf
 
 ##

--- a/2.13inch_e-paper/raspberrypi/python/epd2in13.py
+++ b/2.13inch_e-paper/raspberrypi/python/epd2in13.py
@@ -214,8 +214,7 @@ class EPD:
         self.set_memory_pointer(0, 0)
         self.send_command(WRITE_RAM)
         # send the color data
-        for i in range(0, self.width / 8 * self.height):
-            self.send_data(color)
+        self.send_data(color)
 
 ##
  #  @brief: update the display

--- a/2.13inch_e-paper/raspberrypi/python/epdif.py
+++ b/2.13inch_e-paper/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/2.13inch_e-paper_b/raspberrypi/python/epd2in13b.py
+++ b/2.13inch_e-paper_b/raspberrypi/python/epd2in13b.py
@@ -190,20 +190,20 @@ class EPD:
     def set_rotate(self, rotate):
         if (rotate == ROTATE_0):
             self.rotate = ROTATE_0
-            self.width = epdif.EPD_WIDTH
-            self.height = epdif.EPD_HEIGHT
+            self.width = EPD_WIDTH
+            self.height = EPD_HEIGHT
         elif (rotate == ROTATE_90): 
             self.rotate = ROTATE_90
-            self.width = epdif.EPD_HEIGHT
-            self.height = epdif.EPD_WIDTH
+            self.width = EPD_HEIGHT
+            self.height = EPD_WIDTH
         elif (rotate == ROTATE_180): 
             self.rotate = ROTATE_180
-            self.width = epdif.EPD_WIDTH
-            self.height = epdif.EPD_HEIGHT
+            self.width = EPD_WIDTH
+            self.height = EPD_HEIGHT
         elif (rotate == ROTATE_270): 
             self.rotate = ROTATE_270
-            self.width = epdif.EPD_HEIGHT
-            self.height = epdif.EPD_WIDTH
+            self.width = EPD_HEIGHT
+            self.height = EPD_WIDTH
 
     def set_pixel(self, frame_buffer, x, y, colored):
         if (x < 0 or x >= self.width or y < 0 or y >= self.height):
@@ -212,17 +212,17 @@ class EPD:
             self.set_absolute_pixel(frame_buffer, x, y, colored)
         elif (self.rotate == ROTATE_90):
             point_temp = x
-            x = epdif.EPD_WIDTH - y
+            x = EPD_WIDTH - y
             y = point_temp
             self.set_absolute_pixel(frame_buffer, x, y, colored)
         elif (self.rotate == ROTATE_180):
-            x = epdif.EPD_WIDTH - x
-            y = epdif.EPD_HEIGHT- y
+            x = EPD_WIDTH - x
+            y = EPD_HEIGHT- y
             self.set_absolute_pixel(frame_buffer, x, y, colored)
         elif (self.rotate == ROTATE_270):
             point_temp = x
             x = y
-            y = epdif.EPD_HEIGHT - point_temp
+            y = EPD_HEIGHT - point_temp
             self.set_absolute_pixel(frame_buffer, x, y, colored)
     
     def set_absolute_pixel(self, frame_buffer, x, y, colored):

--- a/2.13inch_e-paper_b/raspberrypi/python/epd2in13b.py
+++ b/2.13inch_e-paper_b/raspberrypi/python/epd2in13b.py
@@ -139,7 +139,7 @@ class EPD:
         self.delay_ms(200)
 
     def get_frame_buffer(self, image):
-        buf = [0xFF] * (self.width * self.height / 8)
+        buf = [0xFF] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -153,20 +153,20 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] == 0:
-                    buf[(x + y * self.width) / 8] &= ~(0x80 >> (x % 8))
+                    buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         return buf
 
     def display_frame(self, frame_buffer_black, frame_buffer_red):
         if (frame_buffer_black != None):
             self.send_command(DATA_START_TRANSMISSION_1)           
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_black[i])  
             self.delay_ms(2)                  
         if (frame_buffer_red != None):
             self.send_command(DATA_START_TRANSMISSION_2)
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_red[i])  
             self.delay_ms(2)        
 
@@ -232,9 +232,9 @@ class EPD:
         if (x < 0 or x >= EPD_WIDTH or y < 0 or y >= EPD_HEIGHT):
             return
         if (colored):
-            frame_buffer[(x + y * EPD_WIDTH) / 8] &= ~(0x80 >> (x % 8))
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] &= ~(0x80 >> (x % 8))
         else:
-            frame_buffer[(x + y * EPD_WIDTH) / 8] |= 0x80 >> (x % 8)
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] |= 0x80 >> (x % 8)
 
     def draw_string_at(self, frame_buffer, x, y, text, font, colored):
         image = Image.new('1', (self.width, self.height))

--- a/2.13inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/2.13inch_e-paper_b/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/2.13inch_e-paper_b/raspberrypi/python/main.py
+++ b/2.13inch_e-paper_b/raspberrypi/python/main.py
@@ -42,13 +42,13 @@ def main():
     frame_red = [0xFF] * (epd.width * epd.height / 8)
 
     # For simplicity, the arguments are explicit numerical coordinates
-    epd.draw_rectangle(frame_black, 10, 60, 50, 100, COLORED);
-    epd.draw_line(frame_black, 10, 60, 50, 100, COLORED);
-    epd.draw_line(frame_black, 50, 60, 10, 100, COLORED);
-    epd.draw_circle(frame_black, 80, 80, 15, COLORED);
-    epd.draw_filled_rectangle(frame_red, 10, 120, 50, 180, COLORED);
-    epd.draw_filled_rectangle(frame_red, 0, 6, 128, 26, COLORED);
-    epd.draw_filled_circle(frame_red, 80, 150, 15, COLORED);
+    epd.draw_rectangle(frame_black, 10, 60, 50, 100, COLORED)
+    epd.draw_line(frame_black, 10, 60, 50, 100, COLORED)
+    epd.draw_line(frame_black, 50, 60, 10, 100, COLORED)
+    epd.draw_circle(frame_black, 80, 80, 15, COLORED)
+    epd.draw_filled_rectangle(frame_red, 10, 120, 50, 180, COLORED)
+    epd.draw_filled_rectangle(frame_red, 0, 6, 128, 26, COLORED)
+    epd.draw_filled_circle(frame_red, 80, 150, 15, COLORED)
 
     # write strings to the buffer
     font = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeMono.ttf', 12)

--- a/2.7inch_e-paper/raspberrypi/python/epd2in7.py
+++ b/2.7inch_e-paper/raspberrypi/python/epd2in7.py
@@ -244,7 +244,7 @@ class EPD:
             self.send_data(self.lut_wb[count])
 
     def get_frame_buffer(self, image):
-        buf = [0x00] * (self.width * self.height / 8)
+        buf = [0x00] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -258,19 +258,19 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] |= (0x80 >> (x % 8))
+                    buf[int((x + y * self.width) / 8)] |= (0x80 >> (x % 8))
         return buf
 
     def display_frame(self, frame_buffer):
         if (frame_buffer != None):
             self.send_command(DATA_START_TRANSMISSION_1)           
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(0xFF)  
             self.delay_ms(2)                  
             self.send_command(DATA_START_TRANSMISSION_2)
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer[i])  
             self.delay_ms(2)        
             self.send_command(DISPLAY_REFRESH) 

--- a/2.7inch_e-paper/raspberrypi/python/epdif.py
+++ b/2.7inch_e-paper/raspberrypi/python/epdif.py
@@ -63,6 +63,6 @@ def epd_init():
 
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/2.7inch_e-paper_b/raspberrypi/python/epd2in7b.py
+++ b/2.7inch_e-paper_b/raspberrypi/python/epd2in7b.py
@@ -259,7 +259,7 @@ class EPD:
             self.send_data(self.lut_wb[count])
 
     def get_frame_buffer(self, image):
-        buf = [0xFF] * (self.width * self.height / 8)
+        buf = [0xFF] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -273,7 +273,7 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] &= ~(0x80 >> (x % 8))
+                    buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         return buf
 
     def display_frame(self, frame_buffer_black, frame_buffer_red):
@@ -286,13 +286,13 @@ class EPD:
         if (frame_buffer_black != None):
             self.send_command(DATA_START_TRANSMISSION_1)           
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_black[i])  
             self.delay_ms(2)                  
         if (frame_buffer_red != None):
             self.send_command(DATA_START_TRANSMISSION_2)
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_red[i])  
             self.delay_ms(2)        
 
@@ -353,9 +353,9 @@ class EPD:
         if (x < 0 or x >= EPD_WIDTH or y < 0 or y >= EPD_HEIGHT):
             return
         if (colored):
-            frame_buffer[(x + y * EPD_WIDTH) / 8] |= 0x80 >> (x % 8)
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] |= 0x80 >> (x % 8)
         else:
-            frame_buffer[(x + y * EPD_WIDTH) / 8] &= ~(0x80 >> (x % 8))
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] &= ~(0x80 >> (x % 8))
 
     def draw_string_at(self, frame_buffer, x, y, text, font, colored):
         image = Image.new('1', (self.width, self.height))

--- a/2.7inch_e-paper_b/raspberrypi/python/epd2in7b.py
+++ b/2.7inch_e-paper_b/raspberrypi/python/epd2in7b.py
@@ -448,8 +448,8 @@ class EPD:
             self.set_pixel(frame_buffer, x + x_pos, y + y_pos, colored)
             self.set_pixel(frame_buffer, x + x_pos, y - y_pos, colored)
             self.set_pixel(frame_buffer, x - x_pos, y - y_pos, colored)
-            self.draw_horizontal_line(frame_buffer, x + x_pos, y + y_pos, 2 * (-x_pos) + 1, colored);
-            self.draw_horizontal_line(frame_buffer, x + x_pos, y - y_pos, 2 * (-x_pos) + 1, colored);
+            self.draw_horizontal_line(frame_buffer, x + x_pos, y + y_pos, 2 * (-x_pos) + 1, colored)
+            self.draw_horizontal_line(frame_buffer, x + x_pos, y - y_pos, 2 * (-x_pos) + 1, colored)
             e2 = err
             if (e2 <= y_pos):
                 y_pos += 1

--- a/2.7inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/2.7inch_e-paper_b/raspberrypi/python/epdif.py
@@ -63,6 +63,6 @@ def epd_init():
 
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/2.7inch_e-paper_b/raspberrypi/python/main.py
+++ b/2.7inch_e-paper_b/raspberrypi/python/main.py
@@ -42,13 +42,13 @@ def main():
     frame_red = [0] * (epd.width * epd.height / 8)
 
     # For simplicity, the arguments are explicit numerical coordinates
-    epd.draw_rectangle(frame_black, 10, 130, 50, 180, COLORED);
-    epd.draw_line(frame_black, 10, 130, 50, 180, COLORED);
-    epd.draw_line(frame_black, 50, 130, 10, 180, COLORED);
-    epd.draw_circle(frame_black, 120, 150, 30, COLORED);
-    epd.draw_filled_rectangle(frame_red, 10, 200, 50, 250, COLORED);
-    epd.draw_filled_rectangle(frame_red, 0, 76, 176, 96, COLORED);
-    epd.draw_filled_circle(frame_red, 120, 220, 30, COLORED);
+    epd.draw_rectangle(frame_black, 10, 130, 50, 180, COLORED)
+    epd.draw_line(frame_black, 10, 130, 50, 180, COLORED)
+    epd.draw_line(frame_black, 50, 130, 10, 180, COLORED)
+    epd.draw_circle(frame_black, 120, 150, 30, COLORED)
+    epd.draw_filled_rectangle(frame_red, 10, 200, 50, 250, COLORED)
+    epd.draw_filled_rectangle(frame_red, 0, 76, 176, 96, COLORED)
+    epd.draw_filled_circle(frame_red, 120, 220, 30, COLORED)
 
     # draw strings to the buffer
     font = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeMonoBold.ttf', 18)

--- a/2.9inch_e-paper/raspberrypi/python/epd2in9.py
+++ b/2.9inch_e-paper/raspberrypi/python/epd2in9.py
@@ -152,7 +152,7 @@ class EPD:
  #  @brief: convert an image to a buffer
  ##
     def get_frame_buffer(self, image):
-        buf = [0x00] * (self.width * self.height / 8)
+        buf = [0x00] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -166,7 +166,7 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] |= 0x80 >> (x % 8)
+                    buf[int((x + y * self.width) / 8)] |= 0x80 >> (x % 8)
         return buf
 
 ##

--- a/2.9inch_e-paper/raspberrypi/python/epd2in9.py
+++ b/2.9inch_e-paper/raspberrypi/python/epd2in9.py
@@ -214,8 +214,7 @@ class EPD:
         self.set_memory_pointer(0, 0)
         self.send_command(WRITE_RAM)
         # send the color data
-        for i in range(0, self.width / 8 * self.height):
-            self.send_data(color)
+        self.send_data(color)
 
 ##
  #  @brief: update the display

--- a/2.9inch_e-paper/raspberrypi/python/epdif.py
+++ b/2.9inch_e-paper/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/2.9inch_e-paper_b/raspberrypi/python/epd2in9b.py
+++ b/2.9inch_e-paper_b/raspberrypi/python/epd2in9b.py
@@ -187,20 +187,20 @@ class EPD:
     def set_rotate(self, rotate):
         if (rotate == ROTATE_0):
             self.rotate = ROTATE_0
-            self.width = epdif.EPD_WIDTH
-            self.height = epdif.EPD_HEIGHT
+            self.width = EPD_WIDTH
+            self.height = EPD_HEIGHT
         elif (rotate == ROTATE_90): 
             self.rotate = ROTATE_90
-            self.width = epdif.EPD_HEIGHT
-            self.height = epdif.EPD_WIDTH
+            self.width = EPD_HEIGHT
+            self.height = EPD_WIDTH
         elif (rotate == ROTATE_180): 
             self.rotate = ROTATE_180
-            self.width = epdif.EPD_WIDTH
-            self.height = epdif.EPD_HEIGHT
+            self.width = EPD_WIDTH
+            self.height = EPD_HEIGHT
         elif (rotate == ROTATE_270): 
             self.rotate = ROTATE_270
-            self.width = epdif.EPD_HEIGHT
-            self.height = epdif.EPD_WIDTH
+            self.width = EPD_HEIGHT
+            self.height = EPD_WIDTH
 
     def set_pixel(self, frame_buffer, x, y, colored):
         if (x < 0 or x >= self.width or y < 0 or y >= self.height):
@@ -209,17 +209,17 @@ class EPD:
             self.set_absolute_pixel(frame_buffer, x, y, colored)
         elif (self.rotate == ROTATE_90):
             point_temp = x
-            x = epdif.EPD_WIDTH - y
+            x = EPD_WIDTH - y
             y = point_temp
             self.set_absolute_pixel(frame_buffer, x, y, colored)
         elif (self.rotate == ROTATE_180):
-            x = epdif.EPD_WIDTH - x
-            y = epdif.EPD_HEIGHT- y
+            x = EPD_WIDTH - x
+            y = EPD_HEIGHT- y
             self.set_absolute_pixel(frame_buffer, x, y, colored)
         elif (self.rotate == ROTATE_270):
             point_temp = x
             x = y
-            y = epdif.EPD_HEIGHT - point_temp
+            y = EPD_HEIGHT - point_temp
             self.set_absolute_pixel(frame_buffer, x, y, colored)
     
     def set_absolute_pixel(self, frame_buffer, x, y, colored):

--- a/2.9inch_e-paper_b/raspberrypi/python/epd2in9b.py
+++ b/2.9inch_e-paper_b/raspberrypi/python/epd2in9b.py
@@ -136,7 +136,7 @@ class EPD:
         self.delay_ms(200)
 
     def get_frame_buffer(self, image):
-        buf = [0xFF] * (self.width * self.height / 8)
+        buf = [0xFF] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -150,20 +150,20 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] == 0:
-                    buf[(x + y * self.width) / 8] &= ~(0x80 >> (x % 8))
+                    buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         return buf
 
     def display_frame(self, frame_buffer_black, frame_buffer_red):
         if (frame_buffer_black != None):
             self.send_command(DATA_START_TRANSMISSION_1)           
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_black[i])  
             self.delay_ms(2)                  
         if (frame_buffer_red != None):
             self.send_command(DATA_START_TRANSMISSION_2)
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_red[i])  
             self.delay_ms(2)        
 
@@ -229,9 +229,9 @@ class EPD:
         if (x < 0 or x >= EPD_WIDTH or y < 0 or y >= EPD_HEIGHT):
             return
         if (colored):
-            frame_buffer[(x + y * EPD_WIDTH) / 8] &= ~(0x80 >> (x % 8))
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] &= ~(0x80 >> (x % 8))
         else:
-            frame_buffer[(x + y * EPD_WIDTH) / 8] |= 0x80 >> (x % 8)
+            frame_buffer[int((x + y * EPD_WIDTH) / 8)] |= 0x80 >> (x % 8)
 
     def draw_string_at(self, frame_buffer, x, y, text, font, colored):
         image = Image.new('1', (self.width, self.height))

--- a/2.9inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/2.9inch_e-paper_b/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/2.9inch_e-paper_b/raspberrypi/python/main.py
+++ b/2.9inch_e-paper_b/raspberrypi/python/main.py
@@ -42,13 +42,13 @@ def main():
     frame_red = [0xFF] * (epd.width * epd.height / 8)
 
     # For simplicity, the arguments are explicit numerical coordinates
-    epd.draw_rectangle(frame_black, 10, 80, 50, 140, COLORED);
-    epd.draw_line(frame_black, 10, 80, 50, 140, COLORED);
-    epd.draw_line(frame_black, 50, 80, 10, 140, COLORED);
-    epd.draw_circle(frame_black, 90, 110, 30, COLORED);
-    epd.draw_filled_rectangle(frame_red, 10, 180, 50, 240, COLORED);
-    epd.draw_filled_rectangle(frame_red, 0, 6, 128, 26, COLORED);
-    epd.draw_filled_circle(frame_red, 90, 210, 30, COLORED);
+    epd.draw_rectangle(frame_black, 10, 80, 50, 140, COLORED)
+    epd.draw_line(frame_black, 10, 80, 50, 140, COLORED)
+    epd.draw_line(frame_black, 50, 80, 10, 140, COLORED)
+    epd.draw_circle(frame_black, 90, 110, 30, COLORED)
+    epd.draw_filled_rectangle(frame_red, 10, 180, 50, 240, COLORED)
+    epd.draw_filled_rectangle(frame_red, 0, 6, 128, 26, COLORED)
+    epd.draw_filled_circle(frame_red, 90, 210, 30, COLORED)
 
     # write strings to the buffer
     font = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeMono.ttf', 16)

--- a/4.2inch_e-paper/raspberrypi/python/epd4in2.py
+++ b/4.2inch_e-paper/raspberrypi/python/epd4in2.py
@@ -74,11 +74,11 @@ POWER_SAVING                                = 0xE3
 
 class EPD:
     def __init__(self):
-        self.reset_pin = epdif.RST_PIN;
-        self.dc_pin = epdif.DC_PIN;
-        self.busy_pin = epdif.BUSY_PIN;
-        self.width = EPD_WIDTH;
-        self.height = EPD_HEIGHT;
+        self.reset_pin = epdif.RST_PIN
+        self.dc_pin = epdif.DC_PIN
+        self.busy_pin = epdif.BUSY_PIN
+        self.width = EPD_WIDTH
+        self.height = EPD_HEIGHT
 
     lut_vcom0 = [
         0x00, 0x17, 0x00, 0x00, 0x00, 0x02,      

--- a/4.2inch_e-paper/raspberrypi/python/epd4in2.py
+++ b/4.2inch_e-paper/raspberrypi/python/epd4in2.py
@@ -206,7 +206,7 @@ class EPD:
             self.send_data(self.lut_wb[count])
 
     def get_frame_buffer(self, image):
-        buf = [0] * (self.width * self.height / 8)
+        buf = [0] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -220,7 +220,7 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] |= 0x80 >> (x % 8)
+                    buf[int((x + y * self.width) / 8)] |= 0x80 >> (x % 8)
         return buf
 
     def display_frame(self, frame_buffer):
@@ -238,11 +238,11 @@ class EPD:
 
         if (frame_buffer != None):
             self.send_command(DATA_START_TRANSMISSION_1)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(0xFF)       # bit set: white, bit reset: black
             self.delay_ms(2)
             self.send_command(DATA_START_TRANSMISSION_2) 
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer[i])
             self.delay_ms(2)                  
 

--- a/4.2inch_e-paper/raspberrypi/python/epdif.py
+++ b/4.2inch_e-paper/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/4.2inch_e-paper_b/raspberrypi/python/epd4in2b.py
+++ b/4.2inch_e-paper_b/raspberrypi/python/epd4in2b.py
@@ -125,7 +125,7 @@ class EPD:
         self.delay_ms(200)
 
     def get_frame_buffer(self, image):
-        buf = [0xFF] * (self.width * self.height / 8)
+        buf = [0xFF] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -139,20 +139,20 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] == 0:
-                    buf[(x + y * self.width) / 8] &= ~(0x80 >> (x % 8))
+                    buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
         return buf
 
     def display_frame(self, frame_buffer_black, frame_buffer_red):
         if (frame_buffer_black != None):
             self.send_command(DATA_START_TRANSMISSION_1)           
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_black[i])  
             self.delay_ms(2)                  
         if (frame_buffer_red != None):
             self.send_command(DATA_START_TRANSMISSION_2)
             self.delay_ms(2)
-            for i in range(0, self.width * self.height / 8):
+            for i in range(0, int(self.width * self.height / 8)):
                 self.send_data(frame_buffer_red[i])  
             self.delay_ms(2)        
 

--- a/4.2inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/4.2inch_e-paper_b/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/7.5inch_e-paper/raspberrypi/python/epd7in5.py
+++ b/7.5inch_e-paper/raspberrypi/python/epd7in5.py
@@ -156,7 +156,7 @@ class EPD:
         self.delay_ms(200)    
 
     def get_frame_buffer(self, image):
-        buf = [0x00] * (self.width * self.height / 8)
+        buf = [0x00] * int(self.width * self.height / 8)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -170,7 +170,7 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] |= 0x80 >> (x % 8)
+                    buf[int((x + y * self.width) / 8)] |= 0x80 >> (x % 8)
         return buf
 
     def display_frame(self, frame_buffer):

--- a/7.5inch_e-paper/raspberrypi/python/epdif.py
+++ b/7.5inch_e-paper/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###

--- a/7.5inch_e-paper_b/raspberrypi/python/epd7in5b.py
+++ b/7.5inch_e-paper_b/raspberrypi/python/epd7in5b.py
@@ -145,7 +145,7 @@ class EPD:
         self.delay_ms(200)    
 
     def get_frame_buffer(self, image):
-        buf = [0x00] * (self.width * self.height / 4)
+        buf = [0x00] * int(self.width * self.height / 4)
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode L.
         image_grayscale = image.convert('L')
@@ -159,17 +159,17 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] < 64:           # black
-                    buf[(x + y * self.width) / 4] &= ~(0xC0 >> (x % 4 * 2))
+                    buf[int((x + y * self.width) / 4)] &= ~(0xC0 >> (x % 4 * 2))
                 elif pixels[x, y] < 192:     # convert gray to red
-                    buf[(x + y * self.width) / 4] &= ~(0xC0 >> (x % 4 * 2))
-                    buf[(x + y * self.width) / 4] |= 0x40 >> (x % 4 * 2)
+                    buf[int((x + y * self.width) / 4)] &= ~(0xC0 >> (x % 4 * 2))
+                    buf[int((x + y * self.width) / 4)] |= 0x40 >> (x % 4 * 2)
                 else:                           # white
-                    buf[(x + y * self.width) / 4] |= 0xC0 >> (x % 4 * 2)
+                    buf[int((x + y * self.width) / 4)] |= 0xC0 >> (x % 4 * 2)
         return buf
 
     def display_frame(self, frame_buffer):
         self.send_command(DATA_START_TRANSMISSION_1)
-        for i in range(0, self.width / 4 * self.height):
+        for i in range(0, int(self.width / 4 * self.height)):
             temp1 = frame_buffer[i]
             j = 0
             while (j < 4):

--- a/7.5inch_e-paper_b/raspberrypi/python/epdif.py
+++ b/7.5inch_e-paper_b/raspberrypi/python/epdif.py
@@ -58,6 +58,6 @@ def epd_init():
     GPIO.setup(BUSY_PIN, GPIO.IN)
     SPI.max_speed_hz = 2000000
     SPI.mode = 0b00
-    return 0;
+    return 0
 
 ### END OF FILE ###


### PR DESCRIPTION
Hi @soonuse!

#11 Library not compatible to Python 3.7.3:
I have carefully added explicit int typecasts wherever integer divisions are performed. This keeps the code compatible with Python 2.x and Python 3.x.

Refactoring:
Refactoring is kept low so you can check the change more easily. I have only removed unnecessary ";" and for loops where the loop variable isn't used.

Testing:
I could only test the change of 7.5inch_e-paper_b since this is the only type I own.

I hope this helps!
BR/flandersen